### PR TITLE
feat: Add slideshow maximize and keyboard navigation

### DIFF
--- a/common.css
+++ b/common.css
@@ -159,3 +159,50 @@ button:hover {
   background-color: rgba(236, 240, 241, 0.8); /* Light Gray with transparency */
   border-radius: 3px;
 }
+
+/* Maximize button for slideshow */
+.maximize-slideshow {
+  position: absolute;
+  top: 10px; /* Adjust as needed */
+  right: 10px; /* Adjust as needed for spacing from the next button if it were outside */
+  padding: 8px 12px;
+  font-size: 0.9em;
+  z-index: 10; /* Ensure it's above slides but potentially below next/prev if they overlap */
+  /* Using existing button styles by default, can be customized further */
+}
+
+/* Styles for maximized slideshow */
+.slideshow-maximized {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: var(--background-color); /* Or a specific overlay color */
+  z-index: 1000; /* Ensure it's on top of everything */
+  overflow-y: auto; /* Allow scrolling if content is too tall */
+}
+
+.slideshow-maximized .slide {
+  height: 100%; /* Make slides take full height of the maximized container */
+  padding: 60px; /* Adjust padding for maximized view */
+  box-sizing: border-box; /* Ensure padding doesn't add to height */
+}
+
+.slideshow-maximized .prev, .slideshow-maximized .next {
+  /* Adjust button positions if needed for maximized view */
+  margin-top: -30px; /* Example adjustment */
+  font-size: 24px; /* Example adjustment */
+  padding: 20px;
+}
+
+.slideshow-maximized .maximize-slideshow {
+  /* Reposition or restyle the maximize/minimize button in maximized state */
+  top: 20px;
+  right: 20px;
+  /* Ensure it's still accessible */
+}
+
+.slideshow-maximized .slide-counter {
+  bottom: 20px; /* Adjust position for maximized view */
+}

--- a/index.html
+++ b/index.html
@@ -48,6 +48,9 @@
             <button class="prev">&#10094;</button>
             <button class="next">&#10095;</button>
 
+            <!-- Maximize button -->
+            <button class="maximize-slideshow">Maximize</button>
+
             <!-- Slide counter -->
             <div class="slide-counter"></div>
         </div>

--- a/slideshow.js
+++ b/slideshow.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const slides = slideshow.querySelectorAll('.slide');
     const prevButton = slideshow.querySelector('.prev');
     const nextButton = slideshow.querySelector('.next');
+    const maximizeButton = slideshow.querySelector('.maximize-slideshow');
     const slideCounter = slideshow.querySelector('.slide-counter');
 
     function showSlide(index) {
@@ -38,9 +39,65 @@ document.addEventListener('DOMContentLoaded', () => {
       nextButton.addEventListener('click', nextSlide);
     }
 
+    if (maximizeButton) {
+      maximizeButton.addEventListener('click', () => {
+        if (slideshow.classList.contains('slideshow-maximized')) {
+          slideshow.classList.remove('slideshow-maximized');
+          maximizeButton.textContent = 'Maximize';
+          // Optional: Restore original scroll position or other states if needed
+        } else {
+          slideshow.classList.add('slideshow-maximized');
+          maximizeButton.textContent = 'Minimize';
+          // Optional: Scroll to top or other adjustments when maximized
+        }
+      });
+    }
+
     // Initialize the first slide
     if (slides.length > 0) {
       showSlide(0);
+    }
+  });
+
+  // Keyboard navigation for all slideshows on the page (if any are active/visible)
+  document.addEventListener('keydown', (e) => {
+    // Find the currently "active" slideshow. This is a simple heuristic:
+    // It assumes the first visible slideshow or the maximized one is the target.
+    // More complex scenarios might need a more robust way to determine the active slideshow.
+    let activeSlideshow = document.querySelector('.slideshow-maximized');
+    if (!activeSlideshow) {
+      // If no slideshow is maximized, find the first one that's at least partially visible.
+      // This part is tricky without knowing exact layout or if multiple slideshows are present.
+      // For simplicity, we'll just target the first slideshow found if not maximized.
+      // A better approach might involve checking if the slideshow is in the viewport.
+      const allSlideshows = document.querySelectorAll('.slideshow-container');
+      if (allSlideshows.length > 0) {
+          // Check if any slideshow is currently visible (e.g. not display:none itself or an ancestor)
+          for(let ss of allSlideshows) {
+              if (ss.offsetParent !== null) { // A simple check for visibility
+                  activeSlideshow = ss;
+                  break;
+              }
+          }
+      }
+    }
+
+    if (activeSlideshow) {
+      // We need to find the specific functions (nextSlide, prevSlide) for this active slideshow.
+      // The current structure of slideshow.js scopes these functions.
+      // To make this work cleanly, we might need to refactor how slideshows are managed
+      // or re-select buttons within the activeSlideshow context here.
+
+      // For now, let's assume we can find the buttons and trigger a click.
+      // This is a workaround. A better way would be to have access to nextSlide/prevSlide directly.
+      const nextButton = activeSlideshow.querySelector('.next');
+      const prevButton = activeSlideshow.querySelector('.prev');
+
+      if (e.key === 'ArrowRight' && nextButton) {
+        nextButton.click(); // Trigger the click event on the next button
+      } else if (e.key === 'ArrowLeft' && prevButton) {
+        prevButton.click(); // Trigger the click event on the prev button
+      }
     }
   });
 });


### PR DESCRIPTION
- Added a 'Maximize' button to the slideshow. Clicking this button toggles a 'slideshow-maximized' class on the slideshow container, causing it to fill the viewport.
- The button text changes to 'Minimize' when maximized and back to 'Maximize' when restored.
- Implemented CSS for the '.slideshow-maximized' state to handle fixed positioning, full viewport dimensions, and adjustments to slide and control element styling.
- Added keyboard navigation using Left and Right arrow keys to control the active slideshow.
- The script detects the maximized slideshow or the first visible one as the target for keyboard controls.